### PR TITLE
Inverted condition to specify user list pages

### DIFF
--- a/src/SynapsePayRest/api/User.php
+++ b/src/SynapsePayRest/api/User.php
@@ -32,7 +32,7 @@ class User{
 
 	function get($user_id=null, $page=null, $per_page=null, $query=null){
 		$path = $this->create_user_path($user_id);
-		if($user_id){
+		if(!$user_id){
 			if($query){
 				$path = $path . '?query=' . $query;
 				if($page){


### PR DESCRIPTION
The condition to acknowledge `$page`, `$per_page` and `$query` attributes was inverted requiring `$user_id` to be set, which then would return a single user information.
