### PR TITLE
Added missing argument to Node->get & fixed condition to get pages

### DIFF
--- a/src/SynapsePayRest/api/Node.php
+++ b/src/SynapsePayRest/api/Node.php
@@ -28,11 +28,11 @@ class Node{
 		return $response;
 	}
 
-	function get($node_id=null, $page=null){
+	function get($node_id=null, $page=null, $per_page=null){
 		$path = $this->create_node_path($node_id);
-		if($node_id){
+		if(!$node_id){
 			if($page){
-				$path = $path . '?page=' . $query;
+				$path = $path . '?page=' . $page;
 				if($per_page){
 					$path = $path . '&per_page=' . $per_page;
 				}


### PR DESCRIPTION
The `$per_page` argument was missing from the `get` method.

The condition to consider `$page` and `$per_page` attributes was inverted requiring `$node_id` to be set.
