### PR TITLE
Allow option for printing to console

### DIFF
--- a/src/SynapsePayRest/HttpClient.php
+++ b/src/SynapsePayRest/HttpClient.php
@@ -3,6 +3,7 @@
 namespace SynapsePayRest;
 
 class HttpClient{
+  protected $printToConsole = true;
 
   function __construct($options, $user_id=null){
     $this->client_id = $options['client_id'];
@@ -16,6 +17,10 @@ class HttpClient{
       $this->baseUrl = 'https://uat-api.synapsefi.com/v3.1';
     }else{
       $this->baseUrl = 'https://api.synapsefi.com/v3.1';
+    }
+
+    if (isset($options['printToConsole'])) {
+      $this->printToConsole = $options['printToConsole'];
     }
   }
 
@@ -64,14 +69,19 @@ class HttpClient{
 
   function handle_response($response,$ch){
     $response = json_decode($response, true);
-    print_r($response);
+    $this->handleOutput($response);
     if($response == false || curl_error($ch)) {
       $err = curl_getinfo($ch);
       curl_close($ch);
       if($response != false){
         return $response;
       }
-      print $this->handle_errors($err);
+
+      if ($this->printToConsole) {
+        print $this->handle_errors($err);
+      } else {
+        $this->handle_errors($err);
+      }
     } else {
       curl_close($ch);
       return $response;
@@ -79,7 +89,7 @@ class HttpClient{
   }
 
   function handle_errors($err){
-    print_r($err);
+    $this->handleOutput($err);
 
     if($err['http_code'] == 0){
       $err['http_code'] = 408;
@@ -132,7 +142,11 @@ class HttpClient{
 
   function get($path){
     $url = $this->baseUrl . $path;
-    print $url;
+
+    if ($this->printToConsole) {
+      print $url;
+    }
+
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_POST, false);
     $options = $this->create_headers($url);
@@ -171,5 +185,12 @@ class HttpClient{
     curl_setopt_array($ch, $options);
     $response = curl_exec($ch);
     return $this->handle_response($response,$ch);
+  }
+
+  private function handleOutput($payload)
+  {
+    if ($this->printToConsole) {
+      print_r($payload);
+    }
   }
 }


### PR DESCRIPTION
**Overview**

Each call to the SynapseFI API prints various output to the console. This includes the base API URL and success or error responses.

**Problem**

Outputting to the console poses two problems:

1. When consuming API services via Ajax that are using the SynapseFI client, if you return the raw result, you get a lot of extra data that can't be JSON parsed properly.
2. `print_r` and `print` both output to the console which would mean that any server-side code that calls the SynapseFI API will potentially be sending its output to log files. At MicroVentures we have seen this in our Papertrail logs as well in our queuing system logs where we have jobs triggered that call SynapseFI code.

**Solution**

This adds a `printToConsole` option that can be passed to `SynapsePayRest\Client` which will then get passed to `SynapsePayRest\HttpClient`. 

If the option is not passed, then it defaults as `true`, which accounts for backwards compatibility for current users.

If the option is passed, then anywhere in `HttpClient` that leverages `print_r()` or `print`, will defer to this option value.

Here are a few examples:

**Using new allowed option**

```php
// Override default behavior: do NOT print to console
$options = [
    // basic options (oath key, fingerprint, ip, etc.)...
    'printToConsole' => false,
];

$client = new Client($options, $userId);
```

**Using new allowed option resulting in existing behavior**

```php
// Same as default behavior: print all responses to console
$options = [
    // basic options (oath key, fingerprint, ip, etc.)...
    'printToConsole' => true,
];

$client = new Client($options, $userId);
```

...which is functionality equivalent to:

```php
// Same as default behavior: print all responses to console
$options = [
    // basic options (oath key, fingerprint, ip, etc.)...
];

$client = new Client($options, $userId);
```