### PR TITLE
Add a statements method onto Nodes

### DIFF
--- a/src/SynapsePayRest/api/Node.php
+++ b/src/SynapsePayRest/api/Node.php
@@ -72,19 +72,19 @@ class Node{
 	}
 
 	function statements($node_id, $page=null, $per_page=null){
-	    $path = $this->create_node_path($node_id) . '/statements';
-        if($page){
-            $path = $path . '?page=' . $page;
-            if($per_page){
-                $path = $path . '&per_page=' . $per_page;
-            }
-        }elseif($per_page){
-            $path = $path . '?per_page=' . $per_page;
-            if($node_type){
-                $path = $path . '&type=' . $node_type;
-            }
-        }
-        $response = $this->client->get($path);
-        return $response;
-    }
+		$path = $this->create_node_path($node_id) . '/statements';
+		if($page){
+			$path = $path . '?page=' . $page;
+			if($per_page){
+				$path = $path . '&per_page=' . $per_page;
+			}
+		}elseif($per_page){
+			$path = $path . '?per_page=' . $per_page;
+			if($node_type){
+				$path = $path . '&type=' . $node_type;
+			}
+		}
+		$response = $this->client->get($path);
+		return $response;
+	}
 }

--- a/src/SynapsePayRest/api/Node.php
+++ b/src/SynapsePayRest/api/Node.php
@@ -80,9 +80,6 @@ class Node{
 			}
 		}elseif($per_page){
 			$path = $path . '?per_page=' . $per_page;
-			if($node_type){
-				$path = $path . '&type=' . $node_type;
-			}
 		}
 		$response = $this->client->get($path);
 		return $response;

--- a/src/SynapsePayRest/api/Node.php
+++ b/src/SynapsePayRest/api/Node.php
@@ -70,4 +70,21 @@ class Node{
 		$response = $this->client->delete($path);
 		return $response;
 	}
+
+	function statements($node_id, $page=null, $per_page=null){
+	    $path = $this->create_node_path($node_id) . '/statements';
+        if($page){
+            $path = $path . '?page=' . $page;
+            if($per_page){
+                $path = $path . '&per_page=' . $per_page;
+            }
+        }elseif($per_page){
+            $path = $path . '?per_page=' . $per_page;
+            if($node_type){
+                $path = $path . '&type=' . $node_type;
+            }
+        }
+        $response = $this->client->get($path);
+        return $response;
+    }
 }


### PR DESCRIPTION
This sdk does not have an ability to retrieve statements from the api. Adding a `statements()` method to the node class fixes this