### PR TITLE
Pass $trans_id when creating path

### DIFF
--- a/src/SynapsePayRest/api/Trans.php
+++ b/src/SynapsePayRest/api/Trans.php
@@ -31,7 +31,7 @@ class Trans{
   }
 
   function get($node_id=null, $trans_id=null, $page=null, $per_page=null){
-    $path = $this->create_trans_path($node_id);
+    $path = $this->create_trans_path($node_id, $trans_id);
     if($node_id){
       if($page){
         $path = $path . '?page=' . $query;


### PR DESCRIPTION
This fixes an issue when attempting to get a single transaction from the API. 

Currently, `$trans_id` is never passed to `create_trans_path` so you can only ever get a paginated list of transactions.

This properly passes `$trans_id` to `create_trans_path` to resolve this issue.